### PR TITLE
Fix: move scenario source file disappearing, etc.

### DIFF
--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -167,8 +167,8 @@ class BiocFileCache:
             session.query(Resource).filter(Resource.rname == rname).first()
         )
 
-        # Resource may exist but rpath could still be being moved/copied into
-        # by add, wait until it exists
+        # `Resource` may exist but `rpath` could still be being moved/copied
+        # into by `add`, wait until `rpath` exists
         while not Path(str(resource.rpath)).exists():
             sleep(0.1)
 

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -125,7 +125,7 @@ class BiocFileCache:
         # exception is raised (such as if it is locked by another process) the
         # data essentially disappears to rpath with no way of retrieving its
         # location. Thus we add rpath to the cache first, then move the data
-        # into it so that the data at source dose not disappear if accessing
+        # into it so that the data at source does not disappear if accessing
         # the cache raises an exception.
         copy_or_move(str(fpath), rpath, rname, action)
 

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -162,7 +162,12 @@ class BiocFileCache:
         Returns:
             res (Resource, optional): The `Resource` for the `rname` if any.
         """
-        return session.query(Resource).filter(Resource.rname == rname).first()
+        resource: Resource = session.query(Resource).filter(Resource.rname == rname).first()
+
+        while not Path(str(resource.rpath)).exists():
+            sleep(0.1)
+
+        return resource
 
     def get(self, rname: str) -> Optional[Resource]:
         """get resource by name from cache.

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -163,14 +163,15 @@ class BiocFileCache:
         Returns:
             res (Resource, optional): The `Resource` for the `rname` if any.
         """
-        resource: Resource = (
+        resource: Optional[Resource] = (
             session.query(Resource).filter(Resource.rname == rname).first()
         )
 
-        # `Resource` may exist but `rpath` could still be being moved/copied
-        # into by `add`, wait until `rpath` exists
-        while not Path(str(resource.rpath)).exists():
-            sleep(0.1)
+        if resource is not None:
+            # `Resource` may exist but `rpath` could still be being
+            # moved/copied into by `add`, wait until `rpath` exists
+            while not Path(str(resource.rpath)).exists():
+                sleep(0.1)
 
         return resource
 

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -4,6 +4,7 @@ Python Implementation of BiocFileCache
 
 import os
 from pathlib import Path
+from time import sleep
 from typing import List, Optional, Union
 
 from sqlalchemy import func
@@ -162,8 +163,12 @@ class BiocFileCache:
         Returns:
             res (Resource, optional): The `Resource` for the `rname` if any.
         """
-        resource: Resource = session.query(Resource).filter(Resource.rname == rname).first()
+        resource: Resource = (
+            session.query(Resource).filter(Resource.rname == rname).first()
+        )
 
+        # Resource may exist but rpath could still be being moved/copied into
+        # by add, wait until it exists
         while not Path(str(resource.rpath)).exists():
             sleep(0.1)
 

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -84,11 +84,7 @@ class BiocFileCache:
             NoFpathError
                 When the `fpath` does not exist.
             RnameExistsError
-                When the `rname` already exists in the cache. If you choose to
-                instead get the file from the cache when this error is raised 
-                make sure to check the `rpath` exists first if it could have
-                been added by a parallel process as the key may exist but the
-                file is in the process of being copied or moved still.
+                When the `rname` already exists in the cache.
             sqlalchemy exceptions
                 When something is up with the cache.
         """

--- a/src/pybiocfilecache/BiocFileCache.py
+++ b/src/pybiocfilecache/BiocFileCache.py
@@ -83,7 +83,11 @@ class BiocFileCache:
             NoFpathError
                 When the `fpath` does not exist.
             RnameExistsError
-                When the `rname` already exists in the cache.
+                When the `rname` already exists in the cache. If you choose to
+                instead get the file from the cache when this error is raised 
+                make sure to check the `rpath` exists first if it could have
+                been added by a parallel process as the key may exist but the
+                file is in the process of being copied or moved still.
             sqlalchemy exceptions
                 When something is up with the cache.
         """

--- a/src/pybiocfilecache/__init__.py
+++ b/src/pybiocfilecache/__init__.py
@@ -15,4 +15,8 @@ except PackageNotFoundError:  # pragma: no cover
 finally:
     del version, PackageNotFoundError
 
-from .BiocFileCache import BiocFileCache
+from .BiocFileCache import BiocFileCache as BiocFileCache
+from .BiocFileCache import NoFpathError as NoFpathError
+from .BiocFileCache import RnameExistsError as RnameExistsError
+from .db.schema import Metadata as Metadata
+from .db.schema import Resource as Resource

--- a/src/pybiocfilecache/db/schema.py
+++ b/src/pybiocfilecache/db/schema.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.sql import func
+
 from .Base import Base
 
 __author__ = "jkanche"


### PR DESCRIPTION
- Fix: fpath could essentially disappear in move scenario if accessing cache threw an error, moved move to after Resource added to cache
- Enhancement: general improvements for parallel caching
- Fix: Due to first fix the Resource can exist but rpath may not have been filled out yet by a parallel process, in `_get` method we must therefore wait until the rpath exists before returning